### PR TITLE
Refactor: fully migrate report submission from frontend Firebase to backend API

### DIFF
--- a/backend/src/main/kotlin/org/cleanupsicily/reporter/ReportController.kt
+++ b/backend/src/main/kotlin/org/cleanupsicily/reporter/ReportController.kt
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 
 @RestController
 @RequestMapping("/api/reports")
@@ -13,12 +15,19 @@ class ReportController(
     private val pdfReportExporter: PdfReportExporter,
     private val csvReportExporter: CsvReportExporter,
     private val mapReportExporter: MapReportExporter,
-    private val excelReportExporter: ExcelReportExporter
+    private val excelReportExporter: ExcelReportExporter,
+    private val reportSubmissionService: ReportSubmissionService
 ) {
 
     @GetMapping
     suspend fun getReports(): List<Map<String, Any>> =
         firestoreService.getReports()
+
+    @PostMapping
+    suspend fun submitReport(@RequestBody data: Map<String, Any?>): ResponseEntity<String> {
+        val id = reportSubmissionService.submitReport(data)
+        return ResponseEntity.ok("Report creato con ID: $id")
+    }
 
     @GetMapping("/export/pdf", produces = [MediaType.APPLICATION_PDF_VALUE])
     suspend fun exportReportsAsPdf(): ResponseEntity<ByteArray> {

--- a/backend/src/main/kotlin/org/cleanupsicily/reporter/ReportSubmissionService.kt
+++ b/backend/src/main/kotlin/org/cleanupsicily/reporter/ReportSubmissionService.kt
@@ -1,0 +1,27 @@
+package org.cleanupsicily.reporter
+
+import com.google.firebase.cloud.FirestoreClient
+import com.google.cloud.firestore.Firestore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class ReportSubmissionService {
+
+    private val firestore: Firestore = FirestoreClient.getFirestore()
+
+    suspend fun submitReport(data: Map<String, Any?>): String {
+        val docRef = firestore.collection("reports").document()
+
+        val toSave = data.toMutableMap()
+        toSave["created_at"] = Instant.now().toString()
+
+        withContext(Dispatchers.IO) {
+            docRef.set(toSave).get()
+        }
+
+        return docRef.id
+    }
+}


### PR DESCRIPTION
- Removed use of Firebase Client SDK (Firestore/Auth/Storage) from frontend
- Disabled Firebase anonymous auth
- Centralized submission via POST /api/reports to Kotlin service
- Deleted unused firebase.js and related imports
- Prepares system for secure multi-platform support (iOS, Android, Desktop, Web)
- Firebase API key and client config are no longer used in the browser